### PR TITLE
REPL Features + Fix

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -74,19 +74,21 @@ class RedisClient {
 				try {
 					let command = line.trim();
 					let commands = splitargs(command);
-					let CMD = commands.shift().toLowerCase();
-					let func = this._redis_client[`${CMD}Async`];
-					if (typeof func == "function") {
-						let result = await func.bind(this._redis_client)(...commands);
-						if (Array.isArray(result)) {
-							result.each((item, index) => {
-								console.log("%d) %s", index, item);
-							});
+					if (commands.length !== 0) { // we have commands, so process, otherwise just a new prompt
+						let CMD = commands.shift().toLowerCase();
+						let func = this._redis_client[`${CMD}Async`];
+						if (typeof func == "function") {
+							let result = await func.bind(this._redis_client)(...commands);
+							if (Array.isArray(result)) {
+								result.each((item, index) => {
+									console.log("%d) %s", index, item);
+								});
+							} else {
+								console.log(result);
+							}
 						} else {
-							console.log(result);
+							console.log(colors.red(`(error) ${CMD} is not support`));
 						}
-					} else {
-						console.log(colors.red(`(error) ${CMD} is not support`));
 					}
 					rl.prompt();
 				} catch (err) {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -79,7 +79,7 @@ class RedisClient {
 						//`exit` and `clear` are not true commands, just part of REPL
 						if (CMD === 'exit') {
 							this._redis_client.quit(() => {
-								process.exit(1);
+								process.exit(0);
 							});
 						} else if (CMD === 'clear') {
 							console.log('\n'.repeat(process.stdout.rows))

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -87,7 +87,7 @@ class RedisClient {
 								console.log(result);
 							}
 						} else {
-							console.log(colors.red(`(error) ${CMD} is not support`));
+							console.log(colors.red(`(error) ${CMD} is not supported`));
 						}
 					}
 					rl.prompt();

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -76,18 +76,29 @@ class RedisClient {
 					let commands = splitargs(command);
 					if (commands.length !== 0) { // we have commands, so process, otherwise just a new prompt
 						let CMD = commands.shift().toLowerCase();
-						let func = this._redis_client[`${CMD}Async`];
-						if (typeof func == "function") {
-							let result = await func.bind(this._redis_client)(...commands);
-							if (Array.isArray(result)) {
-								result.each((item, index) => {
-									console.log("%d) %s", index, item);
-								});
-							} else {
-								console.log(result);
-							}
+						//`exit` and `clear` are not true commands, just part of REPL
+						if (CMD === 'exit') {
+							this._redis_client.quit(() => {
+								process.exit(1);
+							});
+						} else if (CMD === 'clear') {
+							console.log('\n'.repeat(process.stdout.rows))
+							readline.cursorTo(process.stdout, 0, 0)
+							readline.clearScreenDown(process.stdout)
 						} else {
-							console.log(colors.red(`(error) ${CMD} is not supported`));
+							let func = this._redis_client[`${CMD}Async`];
+							if (typeof func == "function") {
+								let result = await func.bind(this._redis_client)(...commands);
+								if (Array.isArray(result)) {
+									result.each((item, index) => {
+										console.log("%d) %s", index, item);
+									});
+								} else {
+									console.log(result);
+								}
+							} else {
+								console.log(colors.red(`(error) ${CMD} is not supported`));
+							}
 						}
 					}
 					rl.prompt();

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -82,9 +82,9 @@ class RedisClient {
 								process.exit(0);
 							});
 						} else if (CMD === 'clear') {
-							console.log('\n'.repeat(process.stdout.rows))
-							readline.cursorTo(process.stdout, 0, 0)
-							readline.clearScreenDown(process.stdout)
+							console.log('\x1b[0f'); /* ANSI clear screen code */
+							readline.cursorTo(process.stdout, 0, 0);
+							readline.clearScreenDown(process.stdout);
 						} else {
 							let func = this._redis_client[`${CMD}Async`];
 							if (typeof func == "function") {


### PR DESCRIPTION
*minor features*
- `exit` command from the REPL cleanly exits the script
- `clear` clears the REPL screen

*minor fixes*
- On a blank prompt, hitting enter/return will now just create a new prompt instead of error message
- Fixed a typo on the unsupported command error message