### PR TITLE
 Redis cluster mode password verification failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ junit.xml
 .DS_Store
 .vscode
 lib
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "redis-cli",
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -51,13 +51,10 @@ export class GUIRedisClient {
 		}
 
 		this.tlsMode = opt.tls;
+		this.auth = opt.auth;
 
 		this.clusters[this.defaultNodeName] = this.createRedisClient(this.defaultNodeName);
 
-		if (opt.auth) {
-			this.defaultClient.auth(opt.auth);
-			this.auth = opt.auth;
-		}
 		this.clusterMode = opt.cluster;
 
 		this.attachRedisEvent(this.defaultClient);
@@ -180,9 +177,7 @@ export class GUIRedisClient {
 	createRedisClient(redis_url: string): RedisClient {
 		const protocol = this.tlsMode ? "rediss://" : "redis://"
 		let client = createClient(protocol + redis_url);
-		if (this.auth) {
-			client.auth(this.auth);
-		}
+		if (this.auth) client.auth(this.auth);
 		promisifyAll(client);
 		return client;
 	}

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -37,6 +37,7 @@ export class GUIRedisClient {
 	private executor: BaseExecutor
 	private clusterMode: boolean
 	private tlsMode: boolean
+	private auth: string
 
 	constructor(opt: GUIRedisClientOption) {
 		this.clusters = {};
@@ -55,6 +56,7 @@ export class GUIRedisClient {
 
 		if (opt.auth) {
 			this.defaultClient.auth(opt.auth);
+			this.auth = opt.auth;
 		}
 		this.clusterMode = opt.cluster;
 
@@ -189,6 +191,9 @@ export class GUIRedisClient {
 				return this.clusters[server];
 			}
 			let client = this.createRedisClient(server);
+			if (this.auth) {
+				client.auth(this.auth);
+			}
 			client.removeAllListeners();
 			client.unref();
 			if (key !== undefined) {

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -180,6 +180,9 @@ export class GUIRedisClient {
 	createRedisClient(redis_url: string): RedisClient {
 		const protocol = this.tlsMode ? "rediss://" : "redis://"
 		let client = createClient(protocol + redis_url);
+		if (this.auth) {
+			client.auth(this.auth);
+		}
 		promisifyAll(client);
 		return client;
 	}
@@ -191,9 +194,6 @@ export class GUIRedisClient {
 				return this.clusters[server];
 			}
 			let client = this.createRedisClient(server);
-			if (this.auth) {
-				client.auth(this.auth);
-			}
 			client.removeAllListeners();
 			client.unref();
 			if (key !== undefined) {


### PR DESCRIPTION
When using the cluster mode, when the -a parameter is used in the main command, and a certain instance of the cluster is successfully connected, if an instance switch occurs, the newly created instance does not automatically use the master password for authorization and the application is interrupted.

